### PR TITLE
added project-slug-feature

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,40 +7,47 @@ import { GitlabCI } from './components/GitlabCI';
 import { rootRouteRef } from './plugin';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-
 const GITLAB_ANNOTATION_PROJECT_ID = 'gitlab.com/project-id';
-export const isGitlabAvailable = (entity: Entity) =>
-Boolean(entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_ID]);
+export const GITLAB_ANNOTATION_PROJECT_SLUG = 'gitlab.com/project-slug';
+
+export const isGitlabAnnotationAvailable = (entity: Entity) =>
+	Boolean(entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_ID]);
+
+export const isGitlabSlugAnnotationAvailable = (entity: Entity) =>
+	Boolean(entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_SLUG]);
 
 type Props = {
-  /** @deprecated The entity is now grabbed from context instead */
-  entity?: Entity;
+	/** @deprecated The entity is now grabbed from context instead */
+	entity?: Entity;
 };
 
-export const Router =  (_props: Props) => {
-  const { entity } = useEntity();
-  
-  if (isGitlabAvailable(entity)) {
-    return (
-      <Routes>
-        <Route
-          path={`/${rootRouteRef.path}`}
-          element={<GitlabCI />}
-        />
-      </Routes>
-    );
-  }
+export const Router = (_props: Props) => {
+	const { entity } = useEntity();
 
-  return (
-    <>
-      <MissingAnnotationEmptyState annotation={GITLAB_ANNOTATION_PROJECT_ID} />
-      <Button
-        variant="contained"
-        color="primary"
-        href="https://github.com/loblaw-sre/backstage-plugin-gitlab/blob/main/README.md"
-      >
-        Read Gitlab Plugin Docs
-      </Button>
-    </>
-  );
+	if (
+		isGitlabAnnotationAvailable(entity) ||
+		isGitlabSlugAnnotationAvailable(entity)
+	) {
+		return (
+			<Routes>
+				<Route path={`/${rootRouteRef.path}`} element={<GitlabCI />} />
+			</Routes>
+		);
+	}
+
+	return (
+		<>
+			<MissingAnnotationEmptyState annotation={GITLAB_ANNOTATION_PROJECT_ID} />
+			<MissingAnnotationEmptyState
+				annotation={GITLAB_ANNOTATION_PROJECT_SLUG}
+			/>
+			<Button
+				variant='contained'
+				color='primary'
+				href='https://github.com/loblaw-sre/backstage-plugin-gitlab/blob/main/README.md'
+			>
+				Read Gitlab Plugin Docs
+			</Button>
+		</>
+	);
 };

--- a/src/api/GitlabCIApi.ts
+++ b/src/api/GitlabCIApi.ts
@@ -1,38 +1,52 @@
 import { createApiRef } from '@backstage/core-plugin-api';
-import { ContributorData, MergeRequest, PipelineObject } from '../components/types';
-
+import {
+	ContributorData,
+	MergeRequest,
+	PipelineObject,
+} from '../components/types';
 
 export interface PipelineSummary {
-  getPipelinesData: PipelineObject[];
+	getPipelinesData: PipelineObject[];
 }
 
 export interface ContributorsSummary {
-  getContributorsData: ContributorData[];
+	getContributorsData: ContributorData[];
 }
 
 export interface MergeRequestsSummary {
-  getMergeRequestsData: MergeRequest[];
+	getMergeRequestsData: MergeRequest[];
 }
 
 export interface MergeRequestsStatusSummary {
-  getMergeRequestsStatusData: MergeRequest[];
+	getMergeRequestsStatusData: MergeRequest[];
 }
 
 export interface LanguagesSummary {
-  getLanguagesData: any;
+	getLanguagesData: any;
 }
 
 export const GitlabCIApiRef = createApiRef<GitlabCIApi>({
-  id: 'plugin.gitlabci.service',
-  description: 'Used by the GitlabCI plugin to make requests',
+	id: 'plugin.gitlabci.service',
+	description: 'Used by the GitlabCI plugin to make requests',
 });
 
 export type GitlabCIApi = {
-  getPipelineSummary(projectID: string): Promise<PipelineSummary | undefined>;
-  getContributorsSummary(projectID: string): Promise<ContributorsSummary | undefined>;
-  getMergeRequestsSummary(projectID: string): Promise<MergeRequestsSummary | undefined>;
-  getMergeRequestsStatusSummary(projectID: string, count: number): Promise<MergeRequestsStatusSummary | undefined>;
-  getProjectName(projectID: string): Promise<string | undefined>;
-  getLanguagesSummary(projectID: string): Promise<LanguagesSummary | undefined>;
-  retryPipelineBuild(projectID: string, pipelineID: string): Promise<Object | undefined>;
+	getPipelineSummary(projectID: string): Promise<PipelineSummary | undefined>;
+	getContributorsSummary(
+		projectID: string,
+	): Promise<ContributorsSummary | undefined>;
+	getMergeRequestsSummary(
+		projectID: string,
+	): Promise<MergeRequestsSummary | undefined>;
+	getMergeRequestsStatusSummary(
+		projectID: string,
+		count: number,
+	): Promise<MergeRequestsStatusSummary | undefined>;
+	getProjectName(projectID: string): Promise<string | undefined>;
+	getLanguagesSummary(projectID: string): Promise<LanguagesSummary | undefined>;
+	retryPipelineBuild(
+		projectID: string,
+		pipelineID: string,
+	): Promise<Object | undefined>;
+	getProjectDetails(projectSlug: string): Promise<Object | undefined>;
 };

--- a/src/api/GitlabCIClient.ts
+++ b/src/api/GitlabCIClient.ts
@@ -1,115 +1,161 @@
-import { PipelineSummary, GitlabCIApi, ContributorsSummary, LanguagesSummary, MergeRequestsSummary, MergeRequestsStatusSummary} from './GitlabCIApi';
+import {
+	PipelineSummary,
+	GitlabCIApi,
+	ContributorsSummary,
+	LanguagesSummary,
+	MergeRequestsSummary,
+	MergeRequestsStatusSummary,
+} from './GitlabCIApi';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
-import { ContributorData, MergeRequest, PipelineObject } from '../components/types';
+import {
+	ContributorData,
+	MergeRequest,
+	PipelineObject,
+} from '../components/types';
 
 export class GitlabCIClient implements GitlabCIApi {
-  discoveryApi: DiscoveryApi;
-  baseUrl: string;
-  constructor({
-    discoveryApi,
-    baseUrl = 'https://gitlab.com/',
-  }: {
-    discoveryApi: DiscoveryApi;
-    baseUrl?: string;
-  }) {
-    this.discoveryApi = discoveryApi;
-    this.baseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  }
+	discoveryApi: DiscoveryApi;
+	baseUrl: string;
+	constructor({
+		discoveryApi,
+		baseUrl = 'https://gitlab.com/',
+	}: {
+		discoveryApi: DiscoveryApi;
+		baseUrl?: string;
+	}) {
+		this.discoveryApi = discoveryApi;
+		this.baseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+	}
 
-   private async callApi<T>(
-     path: string,
-     query: { [key in string]: any },
-   ): Promise<T | undefined> {
-     const apiUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/gitlabci`;
-     const response = await fetch(
-       `${apiUrl}/${path}?${new URLSearchParams(query).toString()}`,
-     );
-   if (response.status === 200) {
-       return (await response.json()) as T;
-     }
-     return undefined;
-   }
+	private async callApi<T>(
+		path: string,
+		query: { [key in string]: any },
+	): Promise<T | undefined> {
+		const apiUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/gitlabci`;
+		const response = await fetch(
+			`${apiUrl}/${path}?${new URLSearchParams(query).toString()}`,
+		);
+		if (response.status === 200) {
+			return (await response.json()) as T;
+		}
+		return undefined;
+	}
 
+	async getPipelineSummary(
+		projectID?: string,
+	): Promise<PipelineSummary | undefined> {
+		const pipelineObjects = await this.callApi<PipelineObject[]>(
+			'projects/' + projectID + '/pipelines',
+			{},
+		);
+		let projectObj: any = await this.callApi<Object>(
+			'projects/' + projectID,
+			{},
+		);
+		if (pipelineObjects) {
+			pipelineObjects.forEach((element: PipelineObject) => {
+				element.project_name = projectObj?.name;
+			});
+		}
+		return {
+			getPipelinesData: pipelineObjects!,
+		};
+	}
 
-  async getPipelineSummary(
-     projectID ?: string,
-  ): Promise<PipelineSummary | undefined> {
-    const pipelineObjects = await this.callApi<PipelineObject[]>('projects/' + projectID + '/pipelines', {});
-    let projectObj:any = await this.callApi<Object>('projects/' + projectID, {});
-    if(pipelineObjects){
-      pipelineObjects.forEach((element: PipelineObject) => {
-       element.project_name = projectObj?.name
-    })
-  }
-    return {
-      getPipelinesData: pipelineObjects!,
-    };
+	async getProjectName(projectID?: string): Promise<string | undefined> {
+		let projectObj: any = await this.callApi<Object>(
+			'projects/' + projectID,
+			{},
+		);
+		return projectObj?.name;
+	}
 
-  }
+	private async getUserProfilesData(
+		contributorsData: ContributorData[],
+	): Promise<ContributorData[]> {
+		for (let i = 0; contributorsData && i < contributorsData.length; i++) {
+			const userProfile: any = await this.callApi<Object[]>('users', {
+				search: contributorsData[i].email,
+			});
+			if (userProfile) {
+				userProfile.forEach((userProfileElement: ContributorData) => {
+					if (userProfileElement.name == contributorsData[i].name) {
+						contributorsData[i].avatar_url = userProfileElement?.avatar_url;
+					}
+				});
+			}
+		}
+		return contributorsData;
+	}
 
-  async getProjectName(projectID ?: string): Promise<string | undefined> {
-    let projectObj: any = await this.callApi<Object>('projects/' + projectID, {});
-    return projectObj?.name;
-  }
+	async getMergeRequestsSummary(
+		projectID?: string,
+	): Promise<MergeRequestsSummary | undefined> {
+		const mergeRquestsList = await this.callApi<MergeRequest[]>(
+			'projects/' + projectID + '/merge_requests',
+			{},
+		);
+		return {
+			getMergeRequestsData: mergeRquestsList!,
+		};
+	}
 
-  private async getUserProfilesData(contributorsData: ContributorData[]): Promise<ContributorData[]> {
-      for(let i=0;contributorsData && i<contributorsData.length;i++){
-        const userProfile: any = await this.callApi<Object[]>('users', {search: contributorsData[i].email})
-        if(userProfile) {
-          userProfile.forEach((userProfileElement: ContributorData) => {
-            if(userProfileElement.name == contributorsData[i].name){
-              contributorsData[i].avatar_url = userProfileElement?.avatar_url;
-            }
-          })
-        }
-      }
-    return contributorsData;
-  }
+	async getMergeRequestsStatusSummary(
+		projectID?: string,
+		count?: number,
+	): Promise<MergeRequestsStatusSummary | undefined> {
+		const mergeRequestsList = await this.callApi<MergeRequest[]>(
+			'projects/' + projectID + '/merge_requests',
+			{ per_page: count },
+		);
+		return {
+			getMergeRequestsStatusData: mergeRequestsList!,
+		};
+	}
 
-  async getMergeRequestsSummary(
-    projectID ?: string,
-  ): Promise<MergeRequestsSummary | undefined> {
-   const mergeRquestsList = await this.callApi<MergeRequest[]>('projects/' + projectID + '/merge_requests', {});
-   return {
-     getMergeRequestsData: mergeRquestsList!,
-   };
-  }
+	async getContributorsSummary(
+		projectID?: string,
+	): Promise<ContributorsSummary | undefined> {
+		const contributorsData = await this.callApi<ContributorData[]>(
+			'projects/' + projectID + '/repository/contributors',
+			{ sort: 'desc' },
+		);
+		const updatedContributorsData = await this.getUserProfilesData(
+			contributorsData!,
+		);
+		return {
+			getContributorsData: updatedContributorsData!,
+		};
+	}
 
-  async getMergeRequestsStatusSummary(
-      projectID ?: string,
-      count?: number,
-  ): Promise<MergeRequestsStatusSummary | undefined> {
-      const mergeRequestsList = await this.callApi<MergeRequest[]>('projects/' + projectID + '/merge_requests', {per_page: count});
-      return {
-          getMergeRequestsStatusData: mergeRequestsList!,
-      };
-  }
+	async getLanguagesSummary(
+		projectID?: string,
+	): Promise<LanguagesSummary | undefined> {
+		const languageObjects = await this.callApi<Object>(
+			'projects/' + projectID + '/languages',
+			{},
+		);
+		return {
+			getLanguagesData: languageObjects!,
+		};
+	}
 
- async getContributorsSummary(
-    projectID ?: string,
- ): Promise<ContributorsSummary | undefined> {
-   const contributorsData= await this.callApi<ContributorData[]>('projects/' + projectID + '/repository/contributors', {sort: "desc"});
-   const updatedContributorsData = await this.getUserProfilesData(contributorsData!);
-   return {
-     getContributorsData: updatedContributorsData!,
-   };
- }
+	async getProjectDetails(projectSlug?: string): Promise<Object | undefined> {
+		let projectDetails: any = await this.callApi<Object>(
+			'projects/' + encodeURIComponent(projectSlug),
+			{},
+		);
+		return projectDetails;
+	}
 
-  async getLanguagesSummary(
-      projectID ?: string,
-  ): Promise<LanguagesSummary | undefined> {
-    const languageObjects = await this.callApi<Object>('projects/' + projectID + '/languages', {});
-    return {
-      getLanguagesData: languageObjects!,
-    };
-
-  }
-
-  async retryPipelineBuild(
-    projectID ?: string,
-    pipelineID ?: string,
-): Promise<Object | undefined> {
-  let retryBuild = await this.callApi<Object>('projects/' + projectID + '/pipelines/' + pipelineID + '/retry', {});
-  return retryBuild;
-  }
+	async retryPipelineBuild(
+		projectID?: string,
+		pipelineID?: string,
+	): Promise<Object | undefined> {
+		let retryBuild = await this.callApi<Object>(
+			'projects/' + projectID + '/pipelines/' + pipelineID + '/retry',
+			{},
+		);
+		return retryBuild;
+	}
 }

--- a/src/components/gitlabAppData.tsx
+++ b/src/components/gitlabAppData.tsx
@@ -16,13 +16,23 @@
 
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-export const GITLAB_ANNOTATION_PROJECT_ID = "gitlab.com/project-id";
+export const GITLAB_ANNOTATION_PROJECT_ID = 'gitlab.com/project-id';
+export const GITLAB_ANNOTATION_PROJECT_SLUG = 'gitlab.com/project-slug';
 
 export const gitlabAppData = () => {
-  const { entity } = useEntity();
+	const { entity } = useEntity();
 
-  const project_id =
-    (entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_ID] ?? '');
+	const project_id =
+		entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_ID] ?? '';
 
-  return { project_id };
+	return { project_id };
+};
+
+export const gitlabAppSlug = () => {
+	const { entity } = useEntity();
+
+	const project_slug =
+		entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_SLUG] ?? '';
+
+	return { project_slug };
 };

--- a/src/components/widgets/ContributorsCard/ContributorsCard.tsx
+++ b/src/components/widgets/ContributorsCard/ContributorsCard.tsx
@@ -5,42 +5,47 @@ import { InfoCard, Progress } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
-import { gitlabAppData } from '../../gitlabAppData';
+import { gitlabAppData, gitlabAppSlug } from '../../gitlabAppData';
 import { ContributorsList } from './components/ContributorsList';
 import { ContributorData } from '../../types';
 
-const useStyles = makeStyles(theme => ({
-  infoCard: {
-    marginBottom: theme.spacing(3),
-    '& + .MuiAlert-root': {
-      marginTop: theme.spacing(3),
-    },
-  },
+const useStyles = makeStyles((theme) => ({
+	infoCard: {
+		marginBottom: theme.spacing(3),
+		'& + .MuiAlert-root': {
+			marginTop: theme.spacing(3),
+		},
+	},
 }));
 
 export const ContributorsCard = ({}) => {
-  const classes = useStyles();
-  const GitlabCIAPI = useApi(GitlabCIApiRef);
-  const { project_id } = gitlabAppData();
-  /* TODO: to change the below logic to get contributors data*/ 
-  const { value, loading, error } = useAsync(async (): Promise<ContributorData[]> => {
-    const gitlabObj = await GitlabCIAPI.getContributorsSummary(project_id);
-    const data = gitlabObj?.getContributorsData;
-    return data!;
-  }, []);
+	const classes = useStyles();
+	const GitlabCIAPI = useApi(GitlabCIApiRef);
+	const { project_id } = gitlabAppData();
+	const { project_slug } = gitlabAppSlug();
+	/* TODO: to change the below logic to get contributors data*/
+	const { value, loading, error } = useAsync(async (): Promise<
+		ContributorData[]
+	> => {
+		const projectDetails = await GitlabCIAPI.getProjectDetails(project_slug);
+		let projectId = project_id ? project_id : projectDetails?.id;
+		const gitlabObj = await GitlabCIAPI.getContributorsSummary(projectId);
+		const data = gitlabObj?.getContributorsData;
+		return data!;
+	}, []);
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
-      </Alert>
-    );
-  }
-  return (
-    <InfoCard title="Contributors">
-      <ContributorsList contributors={value || []} />
-    </InfoCard>
-  );
+	if (loading) {
+		return <Progress />;
+	} else if (error) {
+		return (
+			<Alert severity='error' className={classes.infoCard}>
+				{error.message}
+			</Alert>
+		);
+	}
+	return (
+		<InfoCard title='Contributors'>
+			<ContributorsList contributors={value || []} />
+		</InfoCard>
+	);
 };

--- a/src/components/widgets/LanguagesCard/LanguagesCard.tsx
+++ b/src/components/widgets/LanguagesCard/LanguagesCard.tsx
@@ -5,117 +5,118 @@ import { InfoCard, Progress } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
-import { gitlabAppData } from '../../gitlabAppData';
+import { gitlabAppData, gitlabAppSlug } from '../../gitlabAppData';
 import { Chip, Tooltip } from '@material-ui/core';
 import { colors } from './colors';
 
-const useStyles = makeStyles(theme => ({
-  infoCard: {
-    marginBottom: theme.spacing(3),
-    '& + .MuiAlert-root': {
-      marginTop: theme.spacing(3),
-    },
-  },
-  barContainer: {
-    height: theme.spacing(2),
-    marginBottom: theme.spacing(3),
-    borderRadius: '4px',
-    backgroundColor: 'transparent',
-    overflow: 'hidden',
-  },
-  bar: {
-    height: '100%',
-    position: 'relative',
-  },
-  languageDot: {
-    width: '10px',
-    height: '10px',
-    borderRadius: '50%',
-    marginRight: theme.spacing(1),
-    display: 'inline-block',
-  },
-  label: {
-    color: 'inherit',
-  },
+const useStyles = makeStyles((theme) => ({
+	infoCard: {
+		marginBottom: theme.spacing(3),
+		'& + .MuiAlert-root': {
+			marginTop: theme.spacing(3),
+		},
+	},
+	barContainer: {
+		height: theme.spacing(2),
+		marginBottom: theme.spacing(3),
+		borderRadius: '4px',
+		backgroundColor: 'transparent',
+		overflow: 'hidden',
+	},
+	bar: {
+		height: '100%',
+		position: 'relative',
+	},
+	languageDot: {
+		width: '10px',
+		height: '10px',
+		borderRadius: '50%',
+		marginRight: theme.spacing(1),
+		display: 'inline-block',
+	},
+	label: {
+		color: 'inherit',
+	},
 }));
 
 export type Language = {
-  [key: string]: number;
+	[key: string]: number;
 };
 
 export const LanguagesCard = ({}) => {
-  const classes = useStyles();
-  let barWidth = 0;
-  let languageTitle = new String();
-  const GitlabCIAPI = useApi(GitlabCIApiRef);
-  const { project_id } = gitlabAppData();
+	const classes = useStyles();
+	let barWidth = 0;
+	let languageTitle = new String();
+	const GitlabCIAPI = useApi(GitlabCIApiRef);
+	const { project_id } = gitlabAppData();
+	const { project_slug } = gitlabAppSlug();
 
-  const { value, loading, error } = useAsync(async (): Promise<Language> => {
-    const gitlabObj = await GitlabCIAPI.getLanguagesSummary(project_id);
-    const data = gitlabObj?.getLanguagesData;
-    return data;
-  });
+	const { value, loading, error } = useAsync(async (): Promise<Language> => {
+		const projectDetails = await GitlabCIAPI.getProjectDetails(project_slug);
+		let projectId = project_id ? project_id : projectDetails?.id;
+		const gitlabObj = await GitlabCIAPI.getLanguagesSummary(projectId);
+		const data = gitlabObj?.getLanguagesData;
+		return data;
+	});
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return (
-        <Alert severity="error" className={classes.infoCard}>
-          {error.message}
-        </Alert>
-    );
-  }
+	if (loading) {
+		return <Progress />;
+	} else if (error) {
+		return (
+			<Alert severity='error' className={classes.infoCard}>
+				{error.message}
+			</Alert>
+		);
+	}
 
-  return value ? (
-      <InfoCard title="Languages">
-        <div className={classes.barContainer}>
-          {Object.entries(value as Language).map(
-              (language, index: number) => {
-                barWidth = barWidth + language[1] ;
-                languageTitle = (language[0]) + ' ' + language[1] + '%';
-                return (
-                    <Tooltip
-                        title={languageTitle}
-                        placement="bottom-end"
-                        key={language[0]}
-                    >
-                      <div
-                          className={classes.bar}
-                          key={language[0]}
-                          style={{
-                            marginTop: index === 0 ? '0' : `-16px`,
-                            zIndex: Object.keys(value).length - index,
-                            backgroundColor: colors[language[0]]?.color || '#333',
-                            width: `${barWidth}%`,
-                          }}
-                      />
-                    </Tooltip>
-                );
-              }
-          )}
-        </div>
-        {Object.entries(value as Language).map((language) => (
-            <Chip
-                classes={{
-                  label: classes.label,
-                }}
-                label={
-                  <>
-              <span
-                  className={classes.languageDot}
-                  style={{
-                    backgroundColor: colors[language[0]]?.color || '#333',
-                  }}
-              />
-                    <b>{language[0]}</b> - {language[1]}%
-                  </>
-                }
-                variant="outlined"
-                key={language[0]}
-            />
-        ))}
-      </InfoCard>
-  ) : (
-      <InfoCard title="Languages" />
-  );
+	return value ? (
+		<InfoCard title='Languages'>
+			<div className={classes.barContainer}>
+				{Object.entries(value as Language).map((language, index: number) => {
+					barWidth = barWidth + language[1];
+					languageTitle = language[0] + ' ' + language[1] + '%';
+					return (
+						<Tooltip
+							title={languageTitle}
+							placement='bottom-end'
+							key={language[0]}
+						>
+							<div
+								className={classes.bar}
+								key={language[0]}
+								style={{
+									marginTop: index === 0 ? '0' : `-16px`,
+									zIndex: Object.keys(value).length - index,
+									backgroundColor: colors[language[0]]?.color || '#333',
+									width: `${barWidth}%`,
+								}}
+							/>
+						</Tooltip>
+					);
+				})}
+			</div>
+			{Object.entries(value as Language).map((language) => (
+				<Chip
+					classes={{
+						label: classes.label,
+					}}
+					label={
+						<>
+							<span
+								className={classes.languageDot}
+								style={{
+									backgroundColor: colors[language[0]]?.color || '#333',
+								}}
+							/>
+							<b>{language[0]}</b> - {language[1]}%
+						</>
+					}
+					variant='outlined'
+					key={language[0]}
+				/>
+			))}
+		</InfoCard>
+	) : (
+		<InfoCard title='Languages' />
+	);
 };

--- a/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
+++ b/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
@@ -1,134 +1,154 @@
 import React, { useState } from 'react';
 import { Progress } from '@backstage/core-components';
-import { Box, makeStyles, FormControl, FormHelperText, Select, MenuItem } from '@material-ui/core';
+import {
+	Box,
+	makeStyles,
+	FormControl,
+	FormHelperText,
+	Select,
+	MenuItem,
+} from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import { useAsync } from 'react-use';
-import { gitlabAppData } from '../../gitlabAppData';
+import { gitlabAppData, gitlabAppSlug } from '../../gitlabAppData';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
-import { InfoCard, StructuredMetadataTable, InfoCardVariants } from '@backstage/core-components';
-import {MergeRequest} from "../../types";
+import {
+	InfoCard,
+	StructuredMetadataTable,
+	InfoCardVariants,
+} from '@backstage/core-components';
+import { MergeRequest } from '../../types';
 import moment from 'moment';
 import { Entity } from '@backstage/catalog-model';
 
-const useStyles = makeStyles(theme => ({
-    infoCard: {
-        marginBottom: theme.spacing(3),
-        '& + .MuiAlert-root': {
-            marginTop: theme.spacing(3),
-        },
-        '& .MuiCardContent-root': {
-            padding: theme.spacing(2, 1, 2, 2),
-        },
-        '& td': {
-            whiteSpace: 'normal',
-        },
-    },
+const useStyles = makeStyles((theme) => ({
+	infoCard: {
+		marginBottom: theme.spacing(3),
+		'& + .MuiAlert-root': {
+			marginTop: theme.spacing(3),
+		},
+		'& .MuiCardContent-root': {
+			padding: theme.spacing(2, 1, 2, 2),
+		},
+		'& td': {
+			whiteSpace: 'normal',
+		},
+	},
 }));
 
 export type MergeRequestStatsCount = {
-    avgTimeUntilMerge: number;
-    closedCount: number;
-    mergedCount: number;
+	avgTimeUntilMerge: number;
+	closedCount: number;
+	mergedCount: number;
 };
 
 export type MergeStats = {
-    avgTimeUntilMerge: string;
-    mergedToTotalRatio: string;
+	avgTimeUntilMerge: string;
+	mergedToTotalRatio: string;
 };
 
 type Props = {
-    entity?: Entity;
-    variant?: InfoCardVariants;
+	entity?: Entity;
+	variant?: InfoCardVariants;
 };
 
 const MergeRequestStats = (props: Props) => {
-    const [count, setCount] = useState<number>(20);
-    const classes = useStyles();
-    const { project_id } = gitlabAppData();
-    const GitlabCIAPI = useApi(GitlabCIApiRef);
-    const mergeStat: MergeRequestStatsCount = {avgTimeUntilMerge:0, closedCount:0, mergedCount:0};
-    const { value, loading, error } = useAsync(async (): Promise<MergeStats> => {
-        const gitlabObj = await GitlabCIAPI.getMergeRequestsStatusSummary(project_id, count);
-        const data = gitlabObj?.getMergeRequestsStatusData;
-        let renderData: any = { data }
-        renderData.project_name = await GitlabCIAPI.getProjectName(project_id);
-        if(renderData.data){
-            renderData.data.forEach((element : MergeRequest) => {
-                mergeStat.avgTimeUntilMerge += element.merged_at
-                        ? new Date(element.merged_at).getTime() -
-                        new Date(element.created_at).getTime()
-                        : 0;
-                mergeStat.mergedCount += element.merged_at ? 1 : 0;
-                mergeStat.closedCount += element.closed_at ? 1 : 0;
-            })
+	const [count, setCount] = useState<number>(20);
+	const classes = useStyles();
+	const { project_id } = gitlabAppData();
+	const { project_slug } = gitlabAppSlug();
 
-            if(mergeStat.mergedCount === 0) return {
-                avgTimeUntilMerge: 'Never',
-                mergedToTotalRatio: '0%',
-            }
+	const GitlabCIAPI = useApi(GitlabCIApiRef);
+	const mergeStat: MergeRequestStatsCount = {
+		avgTimeUntilMerge: 0,
+		closedCount: 0,
+		mergedCount: 0,
+	};
+	const { value, loading, error } = useAsync(async (): Promise<MergeStats> => {
+		const projectDetails = await GitlabCIAPI.getProjectDetails(project_slug);
+		let projectId = project_id ? project_id : projectDetails?.id;
+		const gitlabObj = await GitlabCIAPI.getMergeRequestsStatusSummary(
+			projectId,
+			count,
+		);
+		const data = gitlabObj?.getMergeRequestsStatusData;
+		let renderData: any = { data };
+		renderData.project_name = await GitlabCIAPI.getProjectName(projectId);
+		if (renderData.data) {
+			renderData.data.forEach((element: MergeRequest) => {
+				mergeStat.avgTimeUntilMerge += element.merged_at
+					? new Date(element.merged_at).getTime() -
+					  new Date(element.created_at).getTime()
+					: 0;
+				mergeStat.mergedCount += element.merged_at ? 1 : 0;
+				mergeStat.closedCount += element.closed_at ? 1 : 0;
+			});
+		}
 
-            const avgTimeUntilMergeDiff = moment.duration(
-                mergeStat.avgTimeUntilMerge / mergeStat.mergedCount,
-            );
+		if (mergeStat.mergedCount === 0)
+			return {
+				avgTimeUntilMerge: 'Never',
+				mergedToTotalRatio: '0%',
+			};
 
-            const avgTimeUntilMerge = avgTimeUntilMergeDiff.humanize();
+		const avgTimeUntilMergeDiff = moment.duration(
+			mergeStat.avgTimeUntilMerge / mergeStat.mergedCount,
+		);
 
-            /*if(mergeStat.closedCount === 0) return {
-                avgTimeUntilMerge: avgTimeUntilMerge,
-                mergedToClosedRatio: '0%',
-            }*/
-        
-            return {
-                avgTimeUntilMerge: avgTimeUntilMerge,
-                mergedToTotalRatio: `${Math.round(
-                    (mergeStat.mergedCount / renderData.data.length) * 100,
-                )}%`,
-            }
-        }
-        return {
-            avgTimeUntilMerge: 'Never',
-            mergedToTotalRatio: '0%',
-        }
-    },[count]);
+		const avgTimeUntilMerge = avgTimeUntilMergeDiff.humanize();
 
-    if (loading) {
-        return <Progress />;
-    } else if (error) {
-        return <Alert severity="error">{error.message}</Alert>;
-    }
+		/*if(mergeStat.closedCount === 0) return {
+            avgTimeUntilMerge: avgTimeUntilMerge,
+            mergedToClosedRatio: '0%',
+        }*/
+		return {
+			avgTimeUntilMerge: avgTimeUntilMerge,
+			mergedToTotalRatio: `${Math.round(
+				(mergeStat.mergedCount / count) * 100,
+			)}%`,
+		};
+	}, [count]);
 
+	if (loading) {
+		return <Progress />;
+	} else if (error) {
+		return <Alert severity='error'>{error.message}</Alert>;
+	}
 
-    return value ? (
-        <InfoCard
-            title="Merge requests statistics" className={classes.infoCard} variant={props.variant} >
-            {/*   <Box position="relative">
+	return value ? (
+		<InfoCard
+			title='Merge requests statistics'
+			className={classes.infoCard}
+			variant={props.variant}
+		>
+			{/*   <Box position="relative">
                     <div> <b>Average time of MR until merge :</b> {value.avgTimeUntilMerge}</div>
                     <div> <b>Merged to closed ratio :</b> {value.mergedToClosedRatio}</div>
                     <>Number of MRs : 20</>
                 </Box>*/}
 
-            <Box position="relative">
-                <StructuredMetadataTable metadata={value} />
-                <Box display="flex" justifyContent="flex-end">
-                    <FormControl>
-                        <Select
-                            value={count}
-                            onChange={event => setCount(Number(event.target.value))}
-                        >
-                            <MenuItem value={10}>10</MenuItem>
-                            <MenuItem value={20}>20</MenuItem>
-                            <MenuItem value={50}>50</MenuItem>
-                            <MenuItem value={100}>100</MenuItem>
-                        </Select>
-                        <FormHelperText>Number of MRs</FormHelperText>
-                    </FormControl>
-                </Box>
-            </Box>
-        </InfoCard>
-    ) : (
-        <InfoCard title="Merge Request Statistics" />
-    );
+			<Box position='relative'>
+				<StructuredMetadataTable metadata={value} />
+				<Box display='flex' justifyContent='flex-end'>
+					<FormControl>
+						<Select
+							value={count}
+							onChange={(event) => setCount(Number(event.target.value))}
+						>
+							<MenuItem value={10}>10</MenuItem>
+							<MenuItem value={20}>20</MenuItem>
+							<MenuItem value={50}>50</MenuItem>
+							<MenuItem value={100}>100</MenuItem>
+						</Select>
+						<FormHelperText>Number of MRs</FormHelperText>
+					</FormControl>
+				</Box>
+			</Box>
+		</InfoCard>
+	) : (
+		<InfoCard title='Merge Request Statistics' />
+	);
 };
 
 export default MergeRequestStats;

--- a/src/components/widgets/MergeRequestsTable/MergeRequestsTable.tsx
+++ b/src/components/widgets/MergeRequestsTable/MergeRequestsTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Table, TableColumn, Progress } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';
 import { useAsync } from 'react-use';
-import { gitlabAppData } from '../../gitlabAppData';
+import { gitlabAppData, gitlabAppSlug } from '../../gitlabAppData';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { MergeRequest } from '../../types';
@@ -43,16 +43,19 @@ export const DenseTable = ({ mergeRequests }: any) => {
 
 export const MergeRequestsTable = ({}) => {
 	const { project_id } = gitlabAppData();
+	const { project_slug } = gitlabAppSlug();
 
 	const GitlabCIAPI = useApi(GitlabCIApiRef);
 
 	const { value, loading, error } = useAsync(async (): Promise<
 		MergeRequest[]
 	> => {
-		const gitlabObj = await GitlabCIAPI.getMergeRequestsSummary(project_id);
+		const projectDetails = await GitlabCIAPI.getProjectDetails(project_slug);
+		let projectId = project_id ? project_id : projectDetails?.id;
+		const gitlabObj = await GitlabCIAPI.getMergeRequestsSummary(projectId);
 		const data = gitlabObj?.getMergeRequestsData;
 		let renderData: any = { data };
-		renderData.project_name = await GitlabCIAPI.getProjectName(project_id);
+		renderData.project_name = await GitlabCIAPI.getProjectName(projectId);
 		return renderData;
 	}, []);
 

--- a/src/components/widgets/PipelinesTable/PipelinesTable.tsx
+++ b/src/components/widgets/PipelinesTable/PipelinesTable.tsx
@@ -2,68 +2,72 @@ import React from 'react';
 import { Table, TableColumn, Progress } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';
 import { useAsync } from 'react-use';
-import { gitlabAppData } from '../../gitlabAppData';
+import { gitlabAppData, gitlabAppSlug } from '../../gitlabAppData';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
-import { 
-  createStatusColumn,
-  createWebURLColumn
- } from './columns';
+import { createStatusColumn, createWebURLColumn } from './columns';
 import { PipelineObject } from '../../types';
 import { getDuration, getElapsedTime } from '../../utils';
 
 export const DenseTable = ({ pipelineObjects }: any) => {
+	const columns: TableColumn[] = [
+		{ title: 'Pipeline_ID', field: 'id' },
+		createStatusColumn(),
+		{ title: 'Branch', field: 'ref' },
+		createWebURLColumn(),
+		{ title: 'Created At', field: 'created_date' },
+		{ title: 'Duration', field: 'duration' },
+	];
+	const title = 'Gitlab Pipelines: ' + pipelineObjects?.project_name;
 
-  const columns: TableColumn[] = [
-    { title: 'Pipeline_ID', field: 'id' },
-    createStatusColumn(),
-    { title: 'Branch', field: 'ref' },
-    createWebURLColumn(),
-    { title: 'Created At', field: 'created_date'},
-    { title: 'Duration', field: 'duration'}
-  ];
-  const title = "Gitlab Pipelines: " + pipelineObjects?.project_name;
+	const data = pipelineObjects.data.map((pipelineObject: PipelineObject) => {
+		return {
+			id: pipelineObject.id,
+			status: pipelineObject.status,
+			ref: pipelineObject.ref,
+			web_url: pipelineObject.web_url,
+			created_date: getElapsedTime(pipelineObject.created_at),
+			duration: getDuration(
+				pipelineObject.created_at,
+				pipelineObject.updated_at,
+			),
+		};
+	});
 
-  const data = pipelineObjects.data.map((pipelineObject: PipelineObject) => {
-    return {
-       id: pipelineObject.id,
-       status: pipelineObject.status,
-       ref: pipelineObject.ref,
-       web_url: pipelineObject.web_url,
-       created_date: getElapsedTime(pipelineObject.created_at),
-       duration: getDuration(pipelineObject.created_at, pipelineObject.updated_at)
-    };
-  });
-
-  return (
-    <Table
-      title={title}
-      options={{ search: true, paging: true }}
-      columns={columns}
-      data={data}   
-    />
-  );
+	return (
+		<Table
+			title={title}
+			options={{ search: true, paging: true }}
+			columns={columns}
+			data={data}
+		/>
+	);
 };
 
-  export const PipelinesTable = ({}) => {
-  const { project_id } = gitlabAppData();
+export const PipelinesTable = ({}) => {
+	const { project_id } = gitlabAppData();
+	const { project_slug } = gitlabAppSlug();
 
-  const GitlabCIAPI = useApi(GitlabCIApiRef);
+	const GitlabCIAPI = useApi(GitlabCIApiRef);
 
-  const { value, loading, error } = useAsync(async (): Promise<PipelineObject[]> => {
-  const gitlabObj = await GitlabCIAPI.getPipelineSummary(project_id);
-  const data = gitlabObj?.getPipelinesData;
-  let renderData: any = { data }
+	const { value, loading, error } = useAsync(async (): Promise<
+		PipelineObject[]
+	> => {
+		const projectDetails = await GitlabCIAPI.getProjectDetails(project_slug);
+		let projectId = project_id ? project_id : projectDetails?.id;
+		const gitlabObj = await GitlabCIAPI.getPipelineSummary(projectId);
+		const data = gitlabObj?.getPipelinesData;
+		let renderData: any = { data };
 
-  renderData.project_name = await GitlabCIAPI.getProjectName(project_id);
-  return renderData;
-}, []);
+		renderData.project_name = await GitlabCIAPI.getProjectName(projectId);
+		return renderData;
+	}, []);
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
-  }
+	if (loading) {
+		return <Progress />;
+	} else if (error) {
+		return <Alert severity='error'>{error.message}</Alert>;
+	}
 
-  return <DenseTable pipelineObjects={value || []} />;
+	return <DenseTable pipelineObjects={value || []} />;
 };


### PR DESCRIPTION
Users don't need to add a Gitlab Project ID in the YAML,
The GitLab plugin can work with or without a `gitlab.com/project-id` annotation, Changes include fetching project details by project slug (mentioned in annotation as `gitlab.com/project-slug` in the YAML) and using the response which includes ProjectId. And then that projectId is used to make an API calls to fetch data for widgets.