### PR TITLE
GitlabCIClient: add credentials: include to fetch

### DIFF
--- a/src/api/GitlabCIClient.ts
+++ b/src/api/GitlabCIClient.ts
@@ -34,6 +34,9 @@ export class GitlabCIClient implements GitlabCIApi {
 		const apiUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/gitlabci`;
 		const response = await fetch(
 			`${apiUrl}/${path}?${new URLSearchParams(query).toString()}`,
+			{
+				credentials: 'include',
+			},
 		);
 		if (response.status === 200) {
 			return (await response.json()) as T;


### PR DESCRIPTION
This is because sometimes you don't use the same URL for backend and frontend.
We use a CDN for the frontend and the backend lives in its own domain so
without this patch the XHR requests are sent unauthenticated and thus don't work.

With that, all is fine. :)