### PR TITLE
Upgrade to backstage latest (0.4.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/core-components": "^0.7.1",
-    "@backstage/core-plugin-api": "^0.1.3",
+    "@backstage/core-components": "^0.8.4",
+    "@backstage/core-plugin-api": "^0.5.0",
     "@backstage/plugin-catalog-react": "^0.6.1",
     "@backstage/theme": "^0.2.8",
     "@material-ui/core": "^4.11.0",
@@ -44,11 +44,11 @@
     "react-use": "^17.2.4"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.8.0",
-    "@backstage/core-app-api": "^0.1.4",
+    "@backstage/cli": "^0.11.0",
+    "@backstage/core-app-api": "^0.4.0",
     "@backstage/plugin-catalog-react": "^0.6.1",
     "@backstage/dev-utils": "^0.2.0",
-    "@backstage/test-utils": "^0.1.14",
+    "@backstage/test-utils": "^0.2.2",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^13.1.8",

--- a/src/api/GitlabCIApi.ts
+++ b/src/api/GitlabCIApi.ts
@@ -27,7 +27,6 @@ export interface LanguagesSummary {
 
 export const GitlabCIApiRef = createApiRef<GitlabCIApi>({
 	id: 'plugin.gitlabci.service',
-	description: 'Used by the GitlabCI plugin to make requests',
 });
 
 export type GitlabCIApi = {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,7 +9,7 @@ import {
 import { GitlabCIApiRef, GitlabCIClient } from './api';
 
 export const rootRouteRef = createRouteRef({
-  title: 'Gitlab',
+  id: 'Gitlab',
 });
 
 export const gitlabPlugin = createPlugin({

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,5 @@
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({
-  title: 'Gitlab',
+  id: 'Gitlab',
 });


### PR DESCRIPTION
While updating my backstage monorepos installation to latest version (0.4.11) I noticed those packages are not updated because this plugin still use old versions:

@backstage/core-components @ ^0.7.1 should be changed to ^0.8.3
@backstage/core-plugin-api @ ^0.1.3 should be changed to ^0.4.1