### PR TITLE
Update dependecies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/loblaw-sre/backstage-plugin-gitlab"
@@ -20,25 +23,24 @@
     "loblaw"
   ],
   "scripts": {
-    "build": "backstage-cli plugin:build",
-    "start": "backstage-cli plugin:serve",
-    "lint": "backstage-cli lint",
-    "test": "backstage-cli test",
-    "diff": "backstage-cli plugin:diff",
-    "prepack": "backstage-cli prepack",
-    "postpack": "backstage-cli postpack",
-    "clean": "backstage-cli clean"
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
     "@backstage/core-components": "^0.9.0",
-    "@backstage/core-plugin-api": "^0.8.0",
-    "@backstage/plugin-catalog-react": "^0.8.1",
+    "@backstage/core-plugin-api": "^1.0.0",
+    "@backstage/plugin-catalog-react": "^1.0.0",
     "@backstage/theme": "^0.2.14",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.60",
     "moment": "^2.29.1",
-    "react-router": "6.0.0-beta.0",
+    "react-router": "6.2.2",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
@@ -46,18 +48,18 @@
     "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.1",
-    "@backstage/core-app-api": "^0.6.0",
+    "@backstage/cli": "^0.16.0",
+    "@backstage/core-app-api": "^1.0.0",
+    "@backstage/dev-utils": "^1.0.0",
     "@backstage/plugin-catalog-react": "^0.8.1",
-    "@backstage/dev-utils": "^0.2.18",
-    "@backstage/test-utils": "^0.3.0",
+    "@backstage/test-utils": "^1.0.0",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.13",
     "cross-fetch": "^3.1.4",
-    "msw": "^0.36.7"
+    "msw": "^0.39.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Due to deprecated dependencies, it is currently not possible to use this plugin (due to incompatibility of some types). Updating dependencies solves the problem.