### PR TITLE
fix: pipeline urls

### DIFF
--- a/src/api/GitlabCIClient.ts
+++ b/src/api/GitlabCIClient.ts
@@ -55,6 +55,8 @@ export class GitlabCIClient implements GitlabCIApi {
 		if (pipelineObjects) {
 			pipelineObjects.forEach((element: PipelineObject) => {
 				element.project_name = projectObj?.name;
+				element.web_url = element.web_url ||
+          			`${this.baseUrl}${projectObj.path_with_namespace}/pipelines/${element.id}`;
 			});
 		}
 		return {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,7 +24,7 @@ export const gitlabPlugin = createPlugin({
       factory: ({ configApi, discoveryApi }) =>
         new GitlabCIClient({
           discoveryApi,
-          baseUrl: configApi.getOptionalString('gitlab.baseUrl'),
+          baseUrl: configApi.getOptionalConfigArray("integrations.gitlab")?.[0].getOptionalString('baseUrl'),
         }),
     }),
   ],


### PR DESCRIPTION
I add the pipeline URLs for the old GitLab API, and I also fixed the problem with the baseUrl that was taken badly from the configuration file.