### PR TITLE
Specify name when creating routable extension

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -32,6 +32,7 @@ export const gitlabPlugin = createPlugin({
 
 export const EntityGitlabContent = gitlabPlugin.provide(
   createRoutableExtension({
+    name: 'EntityGitlabContent',
     component: () =>
     import('./Router').then(m => m.Router),
     mountPoint: rootRouteRef,


### PR DESCRIPTION
Noticed I was getting this error when running tests and this change should hopefully fix it.

```sh
$ backstage-cli package test --coverage
  console.warn
    Declaring extensions without name is DEPRECATED. Make sure that all usages of createReactExtension, createComponentExtension and createRoutableExtension provide a name.
      at createReactExtension (../../../node_modules/@backstage/core-plugin-api/src/extensions/extensions.tsx:56:13)
      at createRoutableExtension (../../../node_modules/@backstage/core-plugin-api/src/extensions/extensions.tsx:9:10)
      at Object.<anonymous> (../../../node_modules/@loblaw/backstage-plugin-gitlab/src/plugin.ts:29:81)
```

Thanks for making this plugin!