### PR TITLE
Fix for getting 404 on Gitlab Issues Board

### DIFF
--- a/src/components/widgets/IssuesTable/IssuesTable.tsx
+++ b/src/components/widgets/IssuesTable/IssuesTable.tsx
@@ -67,7 +67,7 @@ export const IssuesTable = ({}) => {
 		let projectDetails: any = await GitlabCIAPI.getProjectDetails(project_slug);
 		let projectId = project_id ? project_id : projectDetails?.id;
 		let projectName = await GitlabCIAPI.getProjectName(projectId);
-		const gitlabIssuesObject = await GitlabCIAPI.getIssuesSummary(project_id);
+		const gitlabIssuesObject = await GitlabCIAPI.getIssuesSummary(projectId);
 		const data = gitlabIssuesObject?.getIssuesData;
 		let renderData: any = { data, projectName };
 


### PR DESCRIPTION
Hey :wave: 

This should fix #208

As advied, we should be using `projectId` and not `project_id` when looking for issues on a project, otherwise it causes a 404.

Thanks for advising on how to fix @PedroHPAlmeida